### PR TITLE
Framework for supporting multiple years of data

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,6 +64,16 @@ Ship new version to PyPI ::
 
     $ make ship
 
+Adding additional years to a dataset
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Downloader classes for different geography types are defined in modules of :code:`census_map_downloader.geotypes`. For example, the downloader for countie is :code:`census_map_downloader.geotypes.counties.CountiesDownloader`.
+
+If the URL and fields in a shapefile are the same as those for years that are already supported, you can just add the year to the :code:`YEAR_LIST` attribute.
+
+If the fields are the same, but the URL changes between groups of years, add logic to the :code:`url` property method of the downloader classes to alter the URL based on :code:`self.year`.
+
+If the fields and URL change from year to year, consider creating classes for each year and delegating to :code:`census_map_downloader.geotypes.tracts.TractsDownloader` is an example of a class that uses this approach.
 
 Developing the CLI
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -67,7 +67,7 @@ Ship new version to PyPI ::
 Adding additional years to a dataset
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Downloader classes for different geography types are defined in modules of :code:`census_map_downloader.geotypes`. For example, the downloader for countie is :code:`census_map_downloader.geotypes.counties.CountiesDownloader`.
+Downloader classes for different geography types are defined in modules of :code:`census_map_downloader.geotypes`. For example, the downloader for counties is :code:`census_map_downloader.geotypes.counties.CountiesDownloader`.
 
 If the URL and fields in a shapefile are the same as those for years that are already supported, you can just add the year to the :code:`YEAR_LIST` attribute.
 

--- a/census_map_downloader/__init__.py
+++ b/census_map_downloader/__init__.py
@@ -1,28 +1,28 @@
 from .base import BaseDownloader
-from .geotypes.counties import CountiesDownloader2018
-from .geotypes.places import PlacesDownloader2018
-from .geotypes.tracts import TractsDownloader2010
-from .geotypes.zctas import ZctasDownloader2018
-from .geotypes.blocks import BlocksDownloader2018
-from .geotypes.counties_carto import CountiesCartoDownloader2018
-from .geotypes.congress_carto import CongressCartoDownloader2018
-from .geotypes.states_carto import StatesCartoDownloader2018
-from .geotypes.legislativedistrict_lower_carto import LegislativeDistrictLowerCartoDownloader2018
-from .geotypes.legislativedistrict_upper_carto import LegislativeDistrictUpperCartoDownloader2018
-from .geotypes.countysubdivision_carto import CountySubdivisionCartoDownloader2018
+from .geotypes.counties import CountiesDownloader
+from .geotypes.places import PlacesDownloader
+from .geotypes.tracts import TractsDownloader
+from .geotypes.zctas import ZctasDownloader
+from .geotypes.blocks import BlocksDownloader
+from .geotypes.counties_carto import CountiesCartoDownloader
+from .geotypes.congress_carto import CongressCartoDownloader
+from .geotypes.states_carto import StatesCartoDownloader
+from .geotypes.legislativedistrict_lower_carto import LegislativeDistrictLowerCartoDownloader
+from .geotypes.legislativedistrict_upper_carto import LegislativeDistrictUpperCartoDownloader
+from .geotypes.countysubdivision_carto import CountySubdivisionCartoDownloader
 
 
 __all__ = (
     "BaseDownloader",
-    "CountiesDownloader2018",
-    "PlacesDownloader2018",
-    "TractsDownloader2010",
-    "ZctasDownloader2018",
-    "BlocksDownloader2018",
-    "CountiesCartoDownloader2018",
-    "CongressCartoDownloader2018",
-    "StatesCartoDownloader2018",
-    "LegislativeDistrictLowerCartoDownloader2018",
-    "LegislativeDistrictUpperCartoDownloader2018",
-    "CountySubdivisionCartoDownloader2018"
+    "CountiesDownloader",
+    "PlacesDownloader",
+    "TractsDownloader",
+    "ZctasDownloader",
+    "BlocksDownloader",
+    "CountiesCartoDownloader",
+    "CongressCartoDownloader",
+    "StatesCartoDownloader",
+    "LegislativeDistrictLowerCartoDownloader",
+    "LegislativeDistrictUpperCartoDownloader",
+    "CountySubdivisionCartoDownloader"
 )

--- a/census_map_downloader/base.py
+++ b/census_map_downloader/base.py
@@ -179,7 +179,18 @@ class BaseStateListDownloader(BaseDownloader):
         # Loop through all the states and download the shapes
         for state in us.STATES:
             logger.debug(f"Downloading {state}")
-            runner = self.DOWNLOADER_CLASS(state.abbr, data_dir=self.data_dir, year=self.year)
+            try:
+                runner = self.DOWNLOADER_CLASS(state.abbr, data_dir=self.data_dir, year=self.year)
+            except ValueError as e:
+                # Creating the downloader class instance for the state raised
+                # a `ValueError`. This is usually because the geotype isn't
+                # supported for a particular state. For example, Nebraska
+                # only has one chamber, so there's no file for the lower
+                # cabinet.
+                # Log this issue and keep going with the other states.
+                logger.warning(e)
+                continue
+
             runner.run()
 
     def merge(self):

--- a/census_map_downloader/base.py
+++ b/census_map_downloader/base.py
@@ -32,7 +32,7 @@ class BaseDownloader(object):
 
         # Validate the year
         if self.year not in self.YEAR_LIST:
-            raise NotImplementedError("This year is not supported for this geotype")
+            raise ValueError("This year is not supported for this geotype")
 
         # Initialize all the directories we will need
         if not self.data_dir.exists():

--- a/census_map_downloader/cli.py
+++ b/census_map_downloader/cli.py
@@ -14,86 +14,126 @@ import census_map_downloader
     default="./",
     help="The folder where you want to download the data"
 )
+@click.option(
+    "--year",
+    default=None,
+    type=int,
+    help="The vintage of data to download. By default it gets the latest year. Not all data are available for every year."
+)
 @click.pass_context
-def cmd(ctx, data_dir="./"):
+def cmd(ctx, data_dir="./", year=None):
     ctx.ensure_object(dict)
     ctx.obj['data_dir'] = data_dir
+    ctx.obj['year'] = year
 
 
 @cmd.command(help="Download places")
 @click.pass_context
 def places(ctx):
-    obj = census_map_downloader.PlacesDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.PlacesDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download tracts")
 @click.pass_context
 def tracts(ctx):
-    obj = census_map_downloader.TractsDownloader2010(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.TractsDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download counties")
 @click.pass_context
 def counties(ctx):
-    obj = census_map_downloader.CountiesDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.CountiesDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download cartographic counties")
 @click.pass_context
 def counties_carto(ctx):
-    obj = census_map_downloader.CountiesCartoDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.CountiesCartoDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download cartographic congressional districts")
 @click.pass_context
 def congress_carto(ctx):
-    obj = census_map_downloader.CongressCartoDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.CongressCartoDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download cartographic states")
 @click.pass_context
 def states_carto(ctx):
-    obj = census_map_downloader.StatesCartoDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.StatesCartoDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download cartographic state legislative districts(lower)")
 @click.pass_context
 def legislative_lower_carto(ctx):
-    obj = census_map_downloader.LegislativeDistrictLowerCartoDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.LegislativeDistrictLowerCartoDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download cartographic state legislative districts(upper)")
 @click.pass_context
 def legislative_upper_carto(ctx):
-    obj = census_map_downloader.LegislativeDistrictUpperCartoDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.LegislativeDistrictUpperCartoDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download cartographic county subdivisions")
 @click.pass_context
 def countysubdivision(ctx):
-    obj = census_map_downloader.CountySubdivisionCartoDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.CountySubdivisionCartoDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download ZCTAs")
 @click.pass_context
 def zctas(ctx):
-    obj = census_map_downloader.ZctasDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.ZctasDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 
 @cmd.command(help="Download blocks")
 @click.pass_context
 def blocks(ctx):
-    obj = census_map_downloader.BlocksDownloader2018(data_dir=ctx.obj['data_dir'])
+    obj = census_map_downloader.BlocksDownloader(
+        data_dir=ctx.obj['data_dir'],
+        year=ctx.obj['year']
+    )
     obj.run()
 
 

--- a/census_map_downloader/geotypes/blocks.py
+++ b/census_map_downloader/geotypes/blocks.py
@@ -8,12 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class StateBlocksDownloader2018(BaseStateDownloader):
+class StateBlocksDownloader(BaseStateDownloader):
     """
-    Download 2018 blocks for a single state.
+    Download blocks for a single state.
     """
-    YEAR = 2018
-    PROCESSED_NAME = f"blocks_{YEAR}"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = f"blocks"
     # Docs pg 14 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP10": "state_fips",
@@ -26,18 +26,19 @@ class StateBlocksDownloader2018(BaseStateDownloader):
 
     @property
     def url(self):
-        return f"https://www2.census.gov/geo/tiger/TIGER{self.YEAR}/TABBLOCK/tl_{self.YEAR}_{self.state.fips}_tabblock10.zip"
+        return f"https://www2.census.gov/geo/tiger/TIGER{self.year}/TABBLOCK/tl_{self.year}_{self.state.fips}_tabblock10.zip"
 
     @property
     def zip_name(self):
-        return f"tl_{self.YEAR}_{self.state.fips}_tabblock10.zip"
+        return f"tl_{self.year}_{self.state.fips}_tabblock10.zip"
 
 
-class BlocksDownloader2018(BaseStateListDownloader):
+class BlocksDownloader(BaseStateListDownloader):
     """
-    Download all 2018 blocks in the United States.
+    Download all blocks in the United States.
     """
-    DOWNLOADER_CLASS = StateBlocksDownloader2018
+    YEAR_LIST = [2018]
+    DOWNLOADER_CLASS = StateBlocksDownloader
 
     def merge(self):
         """

--- a/census_map_downloader/geotypes/blocks.py
+++ b/census_map_downloader/geotypes/blocks.py
@@ -13,7 +13,7 @@ class StateBlocksDownloader(BaseStateDownloader):
     Download blocks for a single state.
     """
     YEAR_LIST = [2018]
-    PROCESSED_NAME = f"blocks"
+    PROCESSED_NAME = "blocks"
     # Docs pg 14 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP10": "state_fips",

--- a/census_map_downloader/geotypes/congress_carto.py
+++ b/census_map_downloader/geotypes/congress_carto.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class CongressCartoDownloader2018(BaseDownloader):
+class CongressCartoDownloader(BaseDownloader):
     """
-    Download 2018 cartographic congressional districts.
+    Download cartographic congressional districts.
     """
-    PROCESSED_NAME = "congressionaldistricts_carto_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "congressionaldistricts_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fip",
@@ -28,8 +29,8 @@ class CongressCartoDownloader2018(BaseDownloader):
 
     @property
     def url(self):
-        return "https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_us_cd116_500k.zip"
+        return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_us_cd116_500k.zip"
 
     @property
     def zip_name(self):
-        return f"cb_2018_us_cd116_500k.zip"
+        return f"cb_{self.year}_us_cd116_500k.zip"

--- a/census_map_downloader/geotypes/congress_carto.py
+++ b/census_map_downloader/geotypes/congress_carto.py
@@ -19,7 +19,6 @@ class CongressCartoDownloader(BaseDownloader):
         "STATEFP": "state_fip",
         "CD116FP": "congresional_district",
         "GEOID": "geoid",
-        "NAMELSAD": "name",
         "geometry": "geometry",
         "LSAD": "legal_statistical_area",
         "CDSESSN": "congressional_session_code",

--- a/census_map_downloader/geotypes/counties.py
+++ b/census_map_downloader/geotypes/counties.py
@@ -12,7 +12,18 @@ class CountiesDownloader(BaseDownloader):
     """
     Download counties.
     """
-    YEAR_LIST = [2018]
+    YEAR_LIST = [
+        2011,
+        2012,
+        2013,
+        2014,
+        2015,
+        2016,
+        2017,
+        2018,
+        2019,
+        2020,
+    ]
     PROCESSED_NAME = "counties"
     # Docs pg 21 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf)
     FIELD_CROSSWALK = collections.OrderedDict({

--- a/census_map_downloader/geotypes/counties.py
+++ b/census_map_downloader/geotypes/counties.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class CountiesDownloader2018(BaseDownloader):
+class CountiesDownloader(BaseDownloader):
     """
     Download counties.
     """
-    PROCESSED_NAME = "counties_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "counties"
     # Docs pg 21 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -24,8 +25,8 @@ class CountiesDownloader2018(BaseDownloader):
 
     @property
     def url(self):
-        return "https://www2.census.gov/geo/tiger/TIGER2018/COUNTY/tl_2018_us_county.zip"
+        return f"https://www2.census.gov/geo/tiger/TIGER{self.year}/COUNTY/tl_{self.year}_us_county.zip"
 
     @property
     def zip_name(self):
-        return f"tl_2018_us_county.zip"
+        return f"tl_{self.year}_us_county.zip"

--- a/census_map_downloader/geotypes/counties_carto.py
+++ b/census_map_downloader/geotypes/counties_carto.py
@@ -12,7 +12,14 @@ class CountiesCartoDownloader(BaseDownloader):
     """
     Download cartographic counties.
     """
-    YEAR_LIST = [2018]
+    YEAR_LIST = [
+        2014,
+        2015,
+        2016,
+        2017,
+        2018,
+        2019,
+    ]
     PROCESSED_NAME = "counties_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({

--- a/census_map_downloader/geotypes/counties_carto.py
+++ b/census_map_downloader/geotypes/counties_carto.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class CountiesCartoDownloader2018(BaseDownloader):
+class CountiesCartoDownloader(BaseDownloader):
     """
-    Download 2018 cartographic counties.
+    Download cartographic counties.
     """
-    PROCESSED_NAME = "counties_carto_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "counties_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -26,8 +27,8 @@ class CountiesCartoDownloader2018(BaseDownloader):
 
     @property
     def url(self):
-        return "https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_us_county_500k.zip"
+        return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_us_county_500k.zip"
 
     @property
     def zip_name(self):
-        return f"cb_2018_us_county_500k.zip"
+        return f"cb_{self.year}_us_county_500k.zip"

--- a/census_map_downloader/geotypes/countysubdivision_carto.py
+++ b/census_map_downloader/geotypes/countysubdivision_carto.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class StateCountySubdivisionCartoDownloader2018(BaseStateDownloader):
+class StateCountySubdivisionCartoDownloader(BaseStateDownloader):
     """
-    Download 2018 cartographic county subdivisions for a single state.
+    Download cartographic county subdivisions for a single state.
     """
-    PROCESSED_NAME = "county_subdivision_carto_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "county_subdivision_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -27,18 +28,19 @@ class StateCountySubdivisionCartoDownloader2018(BaseStateDownloader):
 
     @property
     def url(self):
-        return f"https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_{self.state.fips}_cousub_500k.zip"
+        return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_{self.state.fips}_cousub_500k.zip"
 
     @property
     def zip_name(self):
-        return f"cb_2018_{self.state.fips}_cousub_500k.zip"
+        return f"cb_{self.year}_{self.state.fips}_cousub_500k.zip"
 
 
-class CountySubdivisionCartoDownloader2018(BaseStateListDownloader):
+class CountySubdivisionCartoDownloader(BaseStateListDownloader):
     """
-    Download all 2018 cartographic county subdivisions in the United States.
+    Download all cartographic county subdivisions in the United States.
     """
-    DOWNLOADER_CLASS = StateCountySubdivisionCartoDownloader2018
+    YEAR_LIST = [2018]
+    DOWNLOADER_CLASS = StateCountySubdivisionCartoDownloader
 
     def merge(self):
         """

--- a/census_map_downloader/geotypes/legislativedistrict_lower_carto.py
+++ b/census_map_downloader/geotypes/legislativedistrict_lower_carto.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class StateLegislativeDistrictLowerCartoDownloader2018(BaseStateDownloader):
+class StateLegislativeDistrictLowerCartoDownloader(BaseStateDownloader):
     """
-    Download 2018 cartographic state legislative districts (lower chamber) for a single state.
+    Download cartographic state legislative districts (lower chamber) for a single state.
     """
-    PROCESSED_NAME = "legislative_district_lower_carto_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "legislative_district_lower_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -26,18 +27,19 @@ class StateLegislativeDistrictLowerCartoDownloader2018(BaseStateDownloader):
 
     @property
     def url(self):
-        return f"https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_{self.state.fips}_sldl_500k.zip"
+        return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_{self.state.fips}_sldl_500k.zip"
 
     @property
     def zip_name(self):
-        return f"cb_2018_{self.state.fips}_sldl_500k.zip"
+        return f"cb_{self.year}_{self.state.fips}_sldl_500k.zip"
 
 
-class LegislativeDistrictLowerCartoDownloader2018(BaseStateListDownloader):
+class LegislativeDistrictLowerCartoDownloader(BaseStateListDownloader):
     """
-    Download all 2018 cartographic state legislative districts (lower chamber) in the United States.
+    Download all cartographic state legislative districts (lower chamber) in the United States.
     """
-    DOWNLOADER_CLASS = StateLegislativeDistrictLowerCartoDownloader2018
+    YEAR_LIST = [2018]
+    DOWNLOADER_CLASS = StateLegislativeDistrictLowerCartoDownloader
 
     def merge(self):
         """

--- a/census_map_downloader/geotypes/legislativedistrict_lower_carto.py
+++ b/census_map_downloader/geotypes/legislativedistrict_lower_carto.py
@@ -25,6 +25,13 @@ class StateLegislativeDistrictLowerCartoDownloader(BaseStateDownloader):
         "AWATER": "water_area"
     })
 
+    def __init__(self, state, data_dir, year):
+        if state == "NE":
+            # Nebraska has a unicameral legislature
+            raise ValueError(f"State {state} is not supported for this geotype")
+
+        super().__init__(state, data_dir, year)
+
     @property
     def url(self):
         return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_{self.state.fips}_sldl_500k.zip"

--- a/census_map_downloader/geotypes/legislativedistrict_upper_carto.py
+++ b/census_map_downloader/geotypes/legislativedistrict_upper_carto.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class StateLegislativeDistrictUpperCartoDownloader2018(BaseStateDownloader):
+class StateLegislativeDistrictUpperCartoDownloader(BaseStateDownloader):
     """
-    Download 2018 cartographic state legislative districts (upper chamber) for a single state.
+    Download cartographic state legislative districts (upper chamber) for a single state.
     """
-    PROCESSED_NAME = "legislative_district_upper_carto_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "legislative_district_upper_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -26,18 +27,19 @@ class StateLegislativeDistrictUpperCartoDownloader2018(BaseStateDownloader):
 
     @property
     def url(self):
-        return f"https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_{self.state.fips}_sldu_500k.zip"
+        return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_{self.state.fips}_sldu_500k.zip"
 
     @property
     def zip_name(self):
-        return f"cb_2018_{self.state.fips}_sldu_500k.zip"
+        return f"cb_{self.year}_{self.state.fips}_sldu_500k.zip"
 
 
-class LegislativeDistrictUpperCartoDownloader2018(BaseStateListDownloader):
+class LegislativeDistrictUpperCartoDownloader(BaseStateListDownloader):
     """
-    Download all 2018 cartographic state legislative districts (upper chamber) in the United States.
+    Download all cartographic state legislative districts (upper chamber) in the United States.
     """
-    DOWNLOADER_CLASS = StateLegislativeDistrictUpperCartoDownloader2018
+    YEAR_LIST = [2018]
+    DOWNLOADER_CLASS = StateLegislativeDistrictUpperCartoDownloader
 
     def merge(self):
         """

--- a/census_map_downloader/geotypes/places.py
+++ b/census_map_downloader/geotypes/places.py
@@ -8,12 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class StatePlacesDownloader2018(BaseStateDownloader):
+class StatePlacesDownloader(BaseStateDownloader):
     """
-    Download 2018 places for a single state.
+    Download places for a single state.
     """
-    YEAR = 2018
-    PROCESSED_NAME = f"places_{YEAR}"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "places"
     # Page 47 https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -25,17 +25,17 @@ class StatePlacesDownloader2018(BaseStateDownloader):
 
     @property
     def url(self):
-        return f"https://www2.census.gov/geo/tiger/TIGER{self.YEAR}/PLACE/tl_{self.YEAR}_{self.state.fips}_place.zip"
+        return f"https://www2.census.gov/geo/tiger/TIGER{self.year}/PLACE/tl_{self.year}_{self.state.fips}_place.zip"
 
     @property
     def zip_name(self):
-        return f"tl_{self.YEAR}_{self.state.fips}_place.zip"
+        return f"tl_{self.year}_{self.state.fips}_place.zip"
 
 
-class PlacesDownloader2018(BaseStateListDownloader):
+class PlacesDownloader(BaseStateListDownloader):
     """
-    Download all 2018 places in the United States.
+    Download all places in the United States.
     """
-    YEAR = 2018
-    PROCESSED_NAME = f"places_{YEAR}"
-    DOWNLOADER_CLASS = StatePlacesDownloader2018
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "places"
+    DOWNLOADER_CLASS = StatePlacesDownloader

--- a/census_map_downloader/geotypes/states_carto.py
+++ b/census_map_downloader/geotypes/states_carto.py
@@ -8,11 +8,12 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class StatesCartoDownloader2018(BaseDownloader):
+class StatesCartoDownloader(BaseDownloader):
     """
-    Download 2018 cartographic states.
+    Download cartographic states.
     """
-    PROCESSED_NAME = "states_carto_2018"
+    YEAR_LIST = [2018]
+    PROCESSED_NAME = "states_carto"
     # Docs (https://www2.census.gov/geo/tiger/GENZ2018/2018_file_name_def.pdf?#)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP": "state_fips",
@@ -25,8 +26,8 @@ class StatesCartoDownloader2018(BaseDownloader):
 
     @property
     def url(self):
-        return "https://www2.census.gov/geo/tiger/GENZ2018/shp/cb_2018_us_state_500k.zip"
+        return f"https://www2.census.gov/geo/tiger/GENZ{self.year}/shp/cb_{self.year}_us_state_500k.zip"
 
     @property
     def zip_name(self):
-        return f"cb_2018_us_state_500k.zip"
+        return f"cb_{self.year}_us_state_500k.zip"

--- a/census_map_downloader/geotypes/tracts.py
+++ b/census_map_downloader/geotypes/tracts.py
@@ -44,7 +44,7 @@ class StateTractsDownloader2000(StateTractsDownloader2010):
         "COUNTYFP00": "county_fips",
         "TRACTCE00": "tract_id",
         "CTIDFP00": "geoid",
-        "NAME10": "tract_name",
+        "NAME00": "tract_name",
         "geometry": "geometry"
     })
 
@@ -73,8 +73,10 @@ class TractsDownloader(BaseStateListDownloader):
     PROCESSED_NAME = f"tracts"
 
     def __init__(self, data_dir=None, year=None):
-        # Delegate to separate classes depending on the year
-        # This approach avoids branching inside the property methods
+        # Delegate to separate classes depending on the year.
+        # This approach avoids branching inside the property methods of the
+        # downloader classes and allows differences in vintages to be defined
+        # in a more declarative way.
         if year == 2000:
             self.DOWNLOADER_CLASS = StateTractsDownloader2000
         else:

--- a/census_map_downloader/geotypes/tracts.py
+++ b/census_map_downloader/geotypes/tracts.py
@@ -60,16 +60,69 @@ class StateTractsDownloader2000(StateTractsDownloader2010):
     def zip_folder(self):
         return f"{self.state.fips}_{self.state.name.upper().replace(' ', '_')}"
 
+
+class StateTractsDownloader2011To2020(BaseStateDownloader):
+    """
+    Download 2011-2020 tracts for a single state.
+    """
+    YEAR_LIST = [
+        2011,
+        2012,
+        2013,
+        2014,
+        2015,
+        2016,
+        2017,
+        2018,
+        2019,
+        2020,
+    ]
+    PROCESSED_NAME = "tracts"
+    # Docs pg 57 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf)
+    FIELD_CROSSWALK = collections.OrderedDict({
+        "STATEFP": "state_fips",
+        "COUNTYFP": "county_fips",
+        "TRACTCE": "tract_id",
+        "GEOID": "geoid",
+        "NAME": "tract_name",
+        "geometry": "geometry"
+    })
+
     @property
-    def geojson_name(self):
-        return f"{self.PROCESSED_NAME}_{self.year}_{self.state.abbr.lower()}.geojson"
+    def url(self):
+        return self.state.shapefile_urls("tract")
+
+    @property
+    def url(self):
+        return f"https://www2.census.gov/geo/tiger/TIGER{self.year}/TRACT/{self.zip_name}"
+
+    @property
+    def zip_name(self):
+        return f"tl_{self.year}_{self.state.fips}_tract.zip"
+
+    @property
+    def zip_folder(self):
+        return f"tl_{self.year}_{self.state.fips}_tract"
 
 
 class TractsDownloader(BaseStateListDownloader):
     """
     Download all 2000 tracts in the United States.
     """
-    YEAR_LIST = [2000, 2010]
+    YEAR_LIST = [
+        2000,
+        2010,
+        2011,
+        2012,
+        2013,
+        2014,
+        2015,
+        2016,
+        2017,
+        2018,
+        2019,
+        2020,
+    ]
     PROCESSED_NAME = "tracts"
 
     def __init__(self, data_dir=None, year=None):
@@ -79,7 +132,9 @@ class TractsDownloader(BaseStateListDownloader):
         # in a more declarative way.
         if year == 2000:
             self.DOWNLOADER_CLASS = StateTractsDownloader2000
-        else:
+        elif year == 2010:
             self.DOWNLOADER_CLASS = StateTractsDownloader2010
+        else:
+            self.DOWNLOADER_CLASS = StateTractsDownloader2011To2020
 
         super().__init__(data_dir, year)

--- a/census_map_downloader/geotypes/tracts.py
+++ b/census_map_downloader/geotypes/tracts.py
@@ -70,7 +70,7 @@ class TractsDownloader(BaseStateListDownloader):
     Download all 2000 tracts in the United States.
     """
     YEAR_LIST = [2000, 2010]
-    PROCESSED_NAME = f"tracts"
+    PROCESSED_NAME = "tracts"
 
     def __init__(self, data_dir=None, year=None):
         # Delegate to separate classes depending on the year.

--- a/census_map_downloader/geotypes/tracts.py
+++ b/census_map_downloader/geotypes/tracts.py
@@ -12,8 +12,8 @@ class StateTractsDownloader2010(BaseStateDownloader):
     """
     Download 2010 tracts for a single state.
     """
-    YEAR = 2010
-    PROCESSED_NAME = f"tracts_{YEAR}"
+    YEAR_LIST = [2010]
+    PROCESSED_NAME = "tracts"
     # Docs pg 57 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP10": "state_fips",
@@ -37,7 +37,7 @@ class StateTractsDownloader2000(StateTractsDownloader2010):
     """
     Download 2000 tracts for a single state.
     """
-    PROCESSED_NAME = "tracts_2000"
+    YEAR_LIST = [2000]
     # Docs pg 57 (https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2010/TGRSHP10SF1.pdf)
     FIELD_CROSSWALK = collections.OrderedDict({
         "STATEFP00": "state_fips",
@@ -62,22 +62,22 @@ class StateTractsDownloader2000(StateTractsDownloader2010):
 
     @property
     def geojson_name(self):
-        return f"{self.PROCESSED_NAME}_{self.state.abbr.lower()}.geojson"
+        return f"{self.PROCESSED_NAME}_{self.year}_{self.state.abbr.lower()}.geojson"
 
 
-class TractsDownloader2010(BaseStateListDownloader):
-    """
-    Download all 2010 tracts in the United States.
-    """
-    YEAR = 2010
-    PROCESSED_NAME = f"tracts_{YEAR}"
-    DOWNLOADER_CLASS = StateTractsDownloader2010
-
-
-class TractsDownloader2000(BaseStateListDownloader):
+class TractsDownloader(BaseStateListDownloader):
     """
     Download all 2000 tracts in the United States.
     """
-    YEAR = 2000
-    PROCESSED_NAME = f"tracts_{YEAR}"
-    DOWNLOADER_CLASS = StateTractsDownloader2000
+    YEAR_LIST = [2000, 2010]
+    PROCESSED_NAME = f"tracts"
+
+    def __init__(self, data_dir=None, year=None):
+        # Delegate to separate classes depending on the year
+        # This approach avoids branching inside the property methods
+        if year == 2000:
+            self.DOWNLOADER_CLASS = StateTractsDownloader2000
+        else:
+            self.DOWNLOADER_CLASS = StateTractsDownloader2010
+
+        super().__init__(data_dir, year)

--- a/census_map_downloader/geotypes/zctas.py
+++ b/census_map_downloader/geotypes/zctas.py
@@ -12,13 +12,13 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-class ZctasDownloader2018(BaseDownloader):
+class ZctasDownloader(BaseDownloader):
     """
     Download 5-digit ZIP Code Tabulation Area
     """
-    YEAR = 2018
+    YEAR_LIST = [2018]
     # Docs pg 62 https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf
-    PROCESSED_NAME = f"zctas_{YEAR}"
+    PROCESSED_NAME = "zctas"
     FIELD_CROSSWALK = collections.OrderedDict({
         "GEOID10": "geoid",
         "geometry": "geometry"
@@ -26,11 +26,11 @@ class ZctasDownloader2018(BaseDownloader):
 
     @property
     def url(self):
-        return "https://www2.census.gov/geo/tiger/TIGER2018/ZCTA5/tl_2018_us_zcta510.zip"
+        return f"https://www2.census.gov/geo/tiger/TIGER{self.year}/ZCTA5/tl_{self.year}_us_zcta510.zip"
 
     @property
     def zip_name(self):
-        return f"tl_2018_us_zcta510.zip"
+        return f"tl_{self.year}_us_zcta510.zip"
 
         # Add a raw download path for the relationships files
     @property

--- a/census_map_downloader/geotypes/zctas.py
+++ b/census_map_downloader/geotypes/zctas.py
@@ -16,7 +16,17 @@ class ZctasDownloader(BaseDownloader):
     """
     Download 5-digit ZIP Code Tabulation Area
     """
-    YEAR_LIST = [2018]
+    YEAR_LIST = [
+        2012,
+        2013,
+        2014,
+        2015,
+        2016,
+        2017,
+        2018,
+        2019,
+        2020,
+    ]
     # Docs pg 62 https://www2.census.gov/geo/pdfs/maps-data/data/tiger/tgrshp2018/TGRSHP2018_TechDoc_Ch3.pdf
     PROCESSED_NAME = "zctas"
     FIELD_CROSSWALK = collections.OrderedDict({

--- a/test.py
+++ b/test.py
@@ -7,7 +7,7 @@ import census_map_downloader
 class CensusMapDownloadUnitTest(unittest.TestCase):
 
     def test_counties(self):
-        census_map_downloader.CountiesDownloader2018().run()
+        census_map_downloader.CountiesDownloader().run()
 
 
 if __name__ == '__main__':

--- a/test.py
+++ b/test.py
@@ -6,6 +6,15 @@ import unittest
 import census_map_downloader
 
 
+class BaseDownloaderTestCase(unittest.TestCase):
+
+    def test_init_unsupported_year(self):
+        """Test that constructor raises an exception for an unsupported year"""
+
+        with self.assertRaises(ValueError):
+            census_map_downloader.BaseDownloader(year=1900)
+
+
 class CountiesDownloaderTestCase(unittest.TestCase):
 
     def setUp(self):

--- a/test.py
+++ b/test.py
@@ -1,13 +1,103 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
+from pathlib import Path
+import shutil
 import unittest
 import census_map_downloader
 
 
-class CensusMapDownloadUnitTest(unittest.TestCase):
+class CountiesDownloaderTestCase(unittest.TestCase):
 
-    def test_counties(self):
-        census_map_downloader.CountiesDownloader().run()
+    def setUp(self):
+        self.MOST_RECENT_YEAR = 2020
+        self.DATA_DIR = Path(__file__).resolve().parent / 'test-data'
+
+        self.DATA_DIR.mkdir(exist_ok=True)
+
+    def tearDown(self):
+        """Tear down test environment"""
+        shutil.rmtree(self.DATA_DIR)
+
+    def test_init_default_year(self):
+        """
+        Test that a default year attribute is set when no year is passed to
+        constructor
+
+        """
+        downloader = census_map_downloader.CountiesDownloader()
+        self.assertEqual(downloader.year, self.MOST_RECENT_YEAR)
+
+    def test_init_specify_year(self):
+        """
+        Test that the year attribute is set to the year passed to the
+        constructor
+
+        """
+        downloader = census_map_downloader.CountiesDownloader(year=2018)
+        self.assertEqual(downloader.year, 2018)
+
+    def test_url_default_year(self):
+        """
+        Test that the download URL reflects the default year when no year is
+        passed to thee constructor
+
+        """
+        downloader = census_map_downloader.CountiesDownloader()
+        self.assertTrue(str(self.MOST_RECENT_YEAR) in downloader.url)
+
+    def test_url_specify_year(self):
+        """
+        Test that the download URL reflects the year passed to the constructor
+
+        """
+        downloader = census_map_downloader.CountiesDownloader(year=2018)
+        self.assertTrue("2018" in downloader.url)
+
+    def test_run_default_year(self):
+        """
+        Test that the default year's shapefile is downloaded and processed
+        when no year is passed to the constructor
+        """
+        # TODO: This is more of an integration test because it makes a request
+        # and touches the filesystem. It might be better to mock
+        # various classes and methods to detect whether things like
+        # urlretrive() are called. We don't need to test their
+        # functionality.
+        downloader = census_map_downloader.CountiesDownloader(
+            data_dir=self.DATA_DIR
+        )
+        downloader.run()
+
+        shapefile_zip_path = self.DATA_DIR / "raw" / f"tl_{self.MOST_RECENT_YEAR}_us_county.zip"
+        self.assertTrue(shapefile_zip_path.is_file())
+        shapefile_path = self.DATA_DIR / "raw" / f"tl_{self.MOST_RECENT_YEAR}_us_county.shp"
+        self.assertTrue(shapefile_path.is_file())
+        geojson_path = self.DATA_DIR / "processed" / f"counties_{self.MOST_RECENT_YEAR}.geojson"
+        self.assertTrue(geojson_path.is_file())
+
+    def test_run_specify_year(self):
+        """
+        Test that the shapefile that is downloaded and processed
+        reflects the year passed to the constructor
+        """
+        # TODO: This is more of an integration test because it makes a request
+        # and touches the filesystem. It might be better to mock
+        # various classes and methods to detect whether things like
+        # urlretrive() are called. We don't need to test their
+        # functionality.
+        year = 2018
+        downloader = census_map_downloader.CountiesDownloader(
+            data_dir=self.DATA_DIR,
+            year=year
+        )
+        downloader.run()
+
+        shapefile_zip_path = self.DATA_DIR / "raw" / f"tl_{year}_us_county.zip"
+        self.assertTrue(shapefile_zip_path.is_file())
+        shapefile_path = self.DATA_DIR / "raw" / f"tl_{year}_us_county.shp"
+        self.assertTrue(shapefile_path.is_file())
+        geojson_path = self.DATA_DIR / "processed" / f"counties_{year}.geojson"
+        self.assertTrue(geojson_path.is_file())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This pull request does not implement all the vintages of every geotype that users are likely to need, but it does set up the API necessary to add this:

- Adds a `--year` argument to the CLI, defaulting to the most recent year
- Adds a `year` argument to the downloader class constructors which sets `self.year`
- Removes the year from the `PROCESSED_NAME` attribute
- Replaces the `YEAR` attribute in the downloader classes with `YEAR_LIST`
- Implements multiple years of data for counties and the cartographic versions of counties as a reference implementation
- Implements multiple years of data for tracts (the classes were already there) as a reference implementation for cases where both fields and URLs vary between vintages
- Maps out the general pattern for adding support for additional vintages more widely in the README

This will be a breaking change for any consumer code that imports the year-based classes. I could continue to support them fairly easily, but it seems not great to expose them through the public API.

I wanted to send this pull request sooner rather than later so the maintainers can review the approach and also so it can get into the master branch ASAP to make it easier for others to contribute support for additional years.

If this is merged, I'll continue to add support for additional years. Issue #8  might be a good place for people to request particular vintages to prioritize.

Finally, this seems like it should get a minor version bump, but I wasn't sure how you all handle versioning, so I left `setup.py` untouched.